### PR TITLE
MdeModulePkg: Fix device path when the boot manager menu is from diff…

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -2405,13 +2405,9 @@ BmRegisterBootManagerMenu (
   CHAR16                             *Description;
   UINTN                              DescriptionLength;
   EFI_DEVICE_PATH_PROTOCOL           *DevicePath;
-  EFI_LOADED_IMAGE_PROTOCOL          *LoadedImage;
-  MEDIA_FW_VOL_FILEPATH_DEVICE_PATH  FileNode;
   UINTN                              HandleCount;
   EFI_HANDLE                         *Handles;
   UINTN                              Index;
-  VOID                               *Data;
-  UINTN                              DataSize;
 
   DevicePath = NULL;
   Description = NULL;
@@ -2437,22 +2433,17 @@ BmRegisterBootManagerMenu (
   }
 
   if (DevicePath == NULL) {
-    Data = NULL;
-    Status = GetSectionFromAnyFv (
+    Status = GetFileDevicePathFromAnyFv (
                PcdGetPtr (PcdBootManagerMenuFile),
                EFI_SECTION_PE32,
                0,
-               (VOID **) &Data,
-               &DataSize
+               &DevicePath
                );
-    if (Data != NULL) {
-      FreePool (Data);
-    }
     if (EFI_ERROR (Status)) {
       DEBUG ((EFI_D_WARN, "[Bds]BootManagerMenu FFS section can not be found, skip its boot option registration\n"));
       return EFI_NOT_FOUND;
     }
-
+    ASSERT (DevicePath != NULL);
     //
     // Get BootManagerMenu application's description from EFI User Interface Section.
     //
@@ -2466,19 +2457,6 @@ BmRegisterBootManagerMenu (
     if (EFI_ERROR (Status)) {
       Description = NULL;
     }
-
-    EfiInitializeFwVolDevicepathNode (&FileNode, PcdGetPtr (PcdBootManagerMenuFile));
-    Status = gBS->HandleProtocol (
-                    gImageHandle,
-                    &gEfiLoadedImageProtocolGuid,
-                    (VOID **) &LoadedImage
-                    );
-    ASSERT_EFI_ERROR (Status);
-    DevicePath = AppendDevicePathNode (
-                   DevicePathFromHandle (LoadedImage->DeviceHandle),
-                   (EFI_DEVICE_PATH_PROTOCOL *) &FileNode
-                   );
-    ASSERT (DevicePath != NULL);
   }
 
   Status = EfiBootManagerInitializeLoadOption (


### PR DESCRIPTION
…erent FV

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3441

When the boot manager menu is from different FV, the current logic still use the
device path of the FV as the module links to this library

Cc: Jian J Wang <jian.j.wang@intel.com>
Cc: Hao A Wu <hao.a.wu@intel.com>
Cc: Zhichao Gao <zhichao.gao@intel.com>
Cc: Ray Ni <ray.ni@intel.com>
Signed-off-by: Zhiguang Liu <zhiguang.liu@intel.com>